### PR TITLE
use daemon thread to avoid blocking clean shutdown

### DIFF
--- a/src/main/java/com/twitter/whiskey/nio/RunLoop.java
+++ b/src/main/java/com/twitter/whiskey/nio/RunLoop.java
@@ -232,6 +232,9 @@ public class RunLoop implements Executor {
 
     // TODO: allow cancellation of scheduled tasks
     private class RunLoopThread extends Thread {
+        public RunLoopThread() {
+            setDaemon(true);
+        }
 
         @Override
         public void run() {


### PR DESCRIPTION
The full fix is probably to allow shutting down clients and their associated Thread.  But at a minimum the runloop thread for a single client shouldn't block clean shutdown of applications.