### PR TITLE
BugFix: Allocate memory to accumulator even when encoding type is unknown

### DIFF
--- a/src/main/java/com/twitter/whiskey/net/Response.java
+++ b/src/main/java/com/twitter/whiskey/net/Response.java
@@ -19,7 +19,7 @@ public class Response {
     private ByteBuffer body;
     private RequestStats stats;
 
-    Response(int statusCode, Headers headers, ByteBuffer body, RequestStats stats) {
+    public Response(int statusCode, Headers headers, ByteBuffer body, RequestStats stats) {
         this.statusCode = statusCode;
         this.headers = headers;
         this.body = body;

--- a/src/main/java/com/twitter/whiskey/util/ZlibInflater.java
+++ b/src/main/java/com/twitter/whiskey/util/ZlibInflater.java
@@ -110,6 +110,8 @@ public class ZlibInflater extends Inflater {
             case UNKNOWN:
                 // Postpone the decision until setInput(...) is called.
                 determineWrapper = true;
+                accumulator = ByteBuffer.allocate(10);
+                accumulator.flip();
                 crc = null;
                 break;
             default:


### PR DESCRIPTION
Currently when the content encoding of the incoming stream is unknown ZlibInflater throws a NPE because it nevertheless tries to buffer some bytes from the stream in order to determine what the encoding type is. 