### PR TITLE
Handle closing stream session correctly when the header has the fin flag set

### DIFF
--- a/src/main/java/com/twitter/whiskey/net/SpdySession.java
+++ b/src/main/java/com/twitter/whiskey/net/SpdySession.java
@@ -497,6 +497,8 @@ class SpdySession implements Session, SpdyFrameDecoderDelegate {
 
         if (stream == null || stream.isClosedRemotely()) {
             sendRstStream(streamId, SPDY_STREAM_INVALID_STREAM);
+        } else if (last) {
+            stream.closeRemotely();
         }
     }
 


### PR DESCRIPTION
Same as https://github.com/twitter/whiskey/pull/19

Currently when the header frame comes with the FIN_FLAG, whiskey does not complete the request because it checks for isClosed() which verifies if the stream is closed both remotely & locally.

This fix closes the stream remotely when it finds the FIN_FLAG set because there should be no more frames that should be received on this stream.
