### PR TITLE
Fix bugs in UniqMultiMap & handle UnresolvedAddressException during Socket creation

### DIFF
--- a/src/main/java/com/twitter/whiskey/net/SessionManager.java
+++ b/src/main/java/com/twitter/whiskey/net/SessionManager.java
@@ -177,7 +177,7 @@ class SessionManager {
                 // Otherwise, if there are no more pending sockets assume we
                 // can't connect for now and fail operations.
                 if (SessionManager.this.connectivity == connectivity &&
-                    !pendingSocketMap.containsKey(connectivity) &&
+                    (!pendingSocketMap.containsKey(connectivity) || pendingSocketMap.get(connectivity).isEmpty()) &&
                     openSessionMap.isEmpty()) {
                     failOperations(throwable);
                 }

--- a/src/main/java/com/twitter/whiskey/nio/Socket.java
+++ b/src/main/java/com/twitter/whiskey/nio/Socket.java
@@ -17,6 +17,7 @@ import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.SocketChannel;
+import java.nio.channels.UnresolvedAddressException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
@@ -58,7 +59,7 @@ public class Socket extends Selectable {
                     channel.configureBlocking(false);
                     channel.connect(new InetSocketAddress(origin.getHost(), origin.getPort()));
                     reregister();
-                } catch (IOException e) {
+                } catch (IOException | UnresolvedAddressException e) {
                     connectFuture.fail(e);
                     closed = true;
                 }

--- a/src/main/java/com/twitter/whiskey/util/UniqueMultiMap.java
+++ b/src/main/java/com/twitter/whiskey/util/UniqueMultiMap.java
@@ -40,6 +40,7 @@ public class UniqueMultiMap<K, V> extends DequeMultiMap<K, V> {
 
         if (inverse.containsKey(value)) removeValue(value);
         super.put(key, value);
+        inverse.put(value, key);
     }
 
     @Override
@@ -69,6 +70,7 @@ public class UniqueMultiMap<K, V> extends DequeMultiMap<K, V> {
         Deque<V> values = map.get(key);
         if (!values.remove(value)) throw new IllegalStateException();
         size--;
+        if (values.isEmpty()) map.remove(key);
         if (sentinel != mutations++) throw new ConcurrentModificationException();
         return key;
     }


### PR DESCRIPTION
This patch involves the following fixes:
- Maintain the state of the inverse map correctly
- Handle UnresolvedAddressException runtime exception thrown by nio.socket.connect() so that whiskey doesn't crash when there is no network connectivity
- Handle a corner case while determining failure of a http operation