### PR TITLE
fix max concurrent stream config behavior

### DIFF
--- a/src/main/java/com/twitter/whiskey/net/SpdyConstants.java
+++ b/src/main/java/com/twitter/whiskey/net/SpdyConstants.java
@@ -13,7 +13,7 @@ public class SpdyConstants {
     static final int PRIORITY_LEVELS = 8;
     static final int SPDY_SESSION_STREAM_ID = 0;
     static final int DEFAULT_INITIAL_WINDOW_SIZE = 65536;
-    static final int DEFAULT_MAX_CONCURRENT_STREAMS = 100;
+    static final int DEFAULT_MAX_CONCURRENT_STREAMS = Integer.MAX_VALUE;
 
     static final int SPDY_SESSION_OK = 0;
     static final int SPDY_SESSION_PROTOCOL_ERROR = 1;

--- a/src/main/java/com/twitter/whiskey/net/SpdyConstants.java
+++ b/src/main/java/com/twitter/whiskey/net/SpdyConstants.java
@@ -13,6 +13,7 @@ public class SpdyConstants {
     static final int PRIORITY_LEVELS = 8;
     static final int SPDY_SESSION_STREAM_ID = 0;
     static final int DEFAULT_INITIAL_WINDOW_SIZE = 65536;
+    static final int DEFAULT_MAX_CONCURRENT_STREAMS = 100;
 
     static final int SPDY_SESSION_OK = 0;
     static final int SPDY_SESSION_PROTOCOL_ERROR = 1;

--- a/src/main/java/com/twitter/whiskey/net/SpdySession.java
+++ b/src/main/java/com/twitter/whiskey/net/SpdySession.java
@@ -54,7 +54,7 @@ class SpdySession implements Session, SpdyFrameDecoderDelegate {
     private int initialReceiveWindow;
     private int sessionSendWindow = DEFAULT_INITIAL_WINDOW_SIZE;
     private int sessionReceiveWindow;
-    private int localMaxConcurrentStreams = 0;
+    private int localMaxConcurrentStreams;
     private int remoteMaxConcurrentStreams = DEFAULT_MAX_CONCURRENT_STREAMS;
     private long latency = -1;
     private boolean receivedGoAwayFrame = false;

--- a/src/main/java/com/twitter/whiskey/net/SpdySession.java
+++ b/src/main/java/com/twitter/whiskey/net/SpdySession.java
@@ -55,7 +55,7 @@ class SpdySession implements Session, SpdyFrameDecoderDelegate {
     private int sessionSendWindow = DEFAULT_INITIAL_WINDOW_SIZE;
     private int sessionReceiveWindow;
     private int localMaxConcurrentStreams = 0;
-    private int remoteMaxConcurrentStreams = 100;
+    private int remoteMaxConcurrentStreams = DEFAULT_MAX_CONCURRENT_STREAMS;
     private long latency = -1;
     private boolean receivedGoAwayFrame = false;
     private boolean sentGoAwayFrame = false;
@@ -670,7 +670,7 @@ class SpdySession implements Session, SpdyFrameDecoderDelegate {
     private void sendClientSettings() {
 
         SpdySettings settings = new SpdySettings();
-        settings.setValue(SpdySettings.MAX_CONCURRENT_STREAMS, 100);
+        settings.setValue(SpdySettings.MAX_CONCURRENT_STREAMS, localMaxConcurrentStreams);
         settings.setValue(SpdySettings.INITIAL_WINDOW_SIZE, initialReceiveWindow);
 
         WriteLogger logger = new WriteLogger("sent SETTINGS (%d)\n" + settings.toString());


### PR DESCRIPTION
introduced single source for default max streams and connected the local max streams variable to the advertised settings in the preface